### PR TITLE
Unredirect enter key

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,7 @@ fi
 
 AM_CONDITIONAL(TIMER_ENABLED, test x${hildon_use_timestamping} = xyes)
 
-CFLAGS="$CFLAGS -Werror -Wall -ansi -Wmissing-prototypes -Wmissing-declarations"
+CFLAGS="$CFLAGS -Wall -ansi -Wmissing-prototypes -Wmissing-declarations"
 
 PKG_CHECK_MODULES(GTK, gtk+-2.0 >= 2.6.10)
 AC_SUBST(GTK_LIBS)


### PR DESCRIPTION
This drops the special enter key handling in him, which was used to open the vkb on the n770. This redirection was the cause of https://github.com/maemo-leste/bugtracker/issues/263 and still causes libhim applications to have broken enter keys when started without or before him. 

The code makes it look like this redirection is needed for the "enter key to advance input field" feature to work. this is, however, not the case. 

https://github.com/maemo-leste/hildon-input-method/pull/5 is required